### PR TITLE
Add body scrollbars when content overflows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,12 @@
 @import 'tailwindcss';
 
+html,
+body {
+  height: 100%;
+  overflow: auto;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
-  height: 100%;
-  overflow: auto;
 }


### PR DESCRIPTION
## Summary
- ensure `html` and `body` are scrollable when content is taller than the viewport

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_685ca807c284832b9a13d43da7afa25d